### PR TITLE
Feature: create comment

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -95,6 +95,7 @@ export class AuthService {
   getAccessToken(user: Partial<Auth>): string {
     return this.jwtService.sign(
       {
+        id: user.id,
         email: user.email,
         sub: user.nickname,
       },
@@ -105,6 +106,7 @@ export class AuthService {
   setRefreshToken(user: Auth, res: Response) {
     const refreshToken = this.jwtService.sign(
       {
+        id: user.id,
         email: user.email,
         sub: user.nickname,
       },

--- a/src/auth/jwt-access.ts
+++ b/src/auth/jwt-access.ts
@@ -11,6 +11,7 @@ export class JwtAccessStrategy extends PassportStrategy(Strategy, 'access') {
   validate(payload) {
     console.log(payload);
     return {
+      id: payload.id,
       email: payload.email,
       nickname: payload.sub,
     };

--- a/src/auth/jwt-refresh.ts
+++ b/src/auth/jwt-refresh.ts
@@ -16,6 +16,7 @@ export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'refresh') {
   validate(payload) {
     console.log(payload);
     return {
+      id: payload.id,
       email: payload.email,
       nickname: payload.sub,
     };

--- a/src/comment/comment-repository.ts
+++ b/src/comment/comment-repository.ts
@@ -9,4 +9,32 @@ export class CommentRepository extends Repository<Comment> {
   constructor(dataSource: DataSource) {
     super(Comment, dataSource.createEntityManager());
   }
+
+  async createComment(
+    postId: number,
+    content: string,
+    userId: number,
+    commentId?: number,
+  ): Promise<Comment> {
+    //entity에서 선언한 것과 변수명 맞춰야 작동함.
+    const auth = new Auth();
+    auth.id = userId;
+
+    const post = new Post();
+    post.id = postId;
+
+    const parentComment = new Comment();
+    parentComment.id = commentId;
+    //대댓글이 아니면
+    if (!commentId) {
+      const comment = this.create({ content, auth, post });
+      await this.save(comment);
+    }
+    //대댓글이면
+    else {
+      const comment = this.create({ content, auth, post, parentComment });
+      await this.save(comment);
+      return comment;
+    }
+  }
 }

--- a/src/comment/comment.controller.ts
+++ b/src/comment/comment.controller.ts
@@ -1,7 +1,35 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, UseGuards, Post, Req, Param } from '@nestjs/common';
 import { CommentService } from './comment.service';
+import { AuthGuard } from '@nestjs/passport';
 
 @Controller('comment')
 export class CommentController {
   constructor(private readonly commentService: CommentService) {}
+
+  @UseGuards(AuthGuard('access'))
+  @Post('/:postId/:commentId')
+  async createComment(
+    @Param('postId') postId: number,
+    @Param('commentId') commentId: number,
+    @Body() body: { content: string },
+    @Req() req,
+  ) {
+    //try, catch는 컨트롤러에서 해서 internal server error 500이 뜨든
+    //error가 뜨면 다른 메세지를 보내주자.
+    try {
+      const newComment = await this.commentService.createComment(
+        postId,
+        body.content,
+        req.user.id,
+        commentId,
+      );
+      return {
+        success: true,
+        msg: '댓글이 성공적으로 달렸습니다.',
+        comment: newComment,
+      };
+    } catch (error) {
+      return { success: false, msg: '댓글을 다는데 실패했습니다.' };
+    }
+  }
 }

--- a/src/comment/comment.module.ts
+++ b/src/comment/comment.module.ts
@@ -4,6 +4,8 @@ import { Comment } from './entity/comment.entity';
 import { CommentController } from './comment.controller';
 import { CommentService } from './comment.service';
 import { CommentRepository } from './comment-repository';
+import { AuthModule } from 'src/auth/auth.module';
+import { AuthService } from 'src/auth/auth.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Comment])],

--- a/src/comment/comment.service.ts
+++ b/src/comment/comment.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { CommentRepository } from './comment-repository';
 import { InjectRepository } from '@nestjs/typeorm';
+import { Comment } from './entity/comment.entity';
 
 @Injectable()
 export class CommentService {
@@ -8,4 +9,18 @@ export class CommentService {
     @InjectRepository(CommentRepository)
     private readonly commentRepository: CommentRepository,
   ) {}
+
+  async createComment(
+    postId: number,
+    content: string,
+    userId: number,
+    commentId?: number,
+  ): Promise<Comment> {
+    return await this.commentRepository.createComment(
+      postId,
+      content,
+      userId,
+      commentId,
+    );
+  }
 }

--- a/src/comment/entity/comment.entity.ts
+++ b/src/comment/entity/comment.entity.ts
@@ -28,4 +28,8 @@ export class Comment extends BaseEntity {
 
   @ManyToOne((type) => Post, (post) => post.comments)
   post: Post;
+
+  //자기참조 : 대댓글
+  @ManyToOne(() => Comment, { nullable: true })
+  parentComment: Comment;
 }

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -9,6 +9,11 @@ import { AuthGuard } from '@nestjs/passport';
 export class PostController {
   constructor(private readonly postService: PostService) {}
 
+  @Get('/tt')
+  async test(@Body() body: { id: number }) {
+    return this.postService.test(body.id);
+  }
+
   @Get('/:page')
   async listPosts(
     @Param('page') page: number,

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -65,4 +65,7 @@ export class PostService {
     }
     return true;
   }
+  async test(id: number): Promise<string> {
+    return await this.postRepository.test(id);
+  }
 }


### PR DESCRIPTION
배운점:
1. createquerybuilder를 사용할때, orderby에 undefined값이 들어가면 오류가 난다.
ex: filter에 값을 안주면 발생했던 문제
2. API만들 때 순서가 /:page 등을 먼저 만들고 /test 를 만들면 /:page에 의해 /test가 씹혀버린다. 순서를 바꾸던가 이름을 바꾸자.
3. A entity에 매핑된 B entity 정보를 같이 load 하려면 relations:[B] 를 걸어서 load할 수 있다. 
그 후, A.B.xx 등으로 B의 xx필드에 접근 가능하다. (typeORM 방식) 
join -> (쿼리방식) 
4. try catch문은 controller에 작성하여 내부적으로 오류가 발생했을시 return 할 오류문을 적어주자.
5. path variable /:xxxx 는 값을 주지 않아도 작동은 한다.
6. query param 도 값을 주지 않아도 작동한다. 